### PR TITLE
compatibility fix for magento 2.3.*

### DIFF
--- a/Plugin/Store/App/Request/PathInfoProcessor.php
+++ b/Plugin/Store/App/Request/PathInfoProcessor.php
@@ -77,6 +77,6 @@ class PathInfoProcessor
         }
 
         $pathParts[0] = $storeCode;
-        return $proceed($request, implode('/', $pathParts));
+        return $proceed($request, "/". implode('/', $pathParts));
     }
 }


### PR DESCRIPTION
@dheesbeen @lewisvoncken 
This change made the module compatible with 2.3 because in Magento 2.1 the Magento/Store/App/Request/PathInfoProcessor.php added this slash hard. This is not happening in 2.3 anymore