### PR TITLE
[BUGFIX] Fixed website_store code fallback 

### DIFF
--- a/Plugin/Store/App/Request/PathInfoProcessor.php
+++ b/Plugin/Store/App/Request/PathInfoProcessor.php
@@ -71,6 +71,6 @@ class PathInfoProcessor
         }
         $websiteCode = $website->getCode();
         $newPath = $this->data->setCorrectWebsiteCodeUrl($websiteCode,$pathInfo,false);
-        return $proceed($request, "/". $newPath);
+        return $proceed($request, "/" . ltrim($newPath, '/'));
     }
 }


### PR DESCRIPTION
Following helper updates urls which have only their storecode to contain website code:
Helper/Data.php:54
Which causes updated urls not have a / at the start.

When url already has the website code, it already has the first /.
In Plugin/Store/App/Request/PathInfoProcessor.php:73 a / gets prepended which leads to some urls having two slashes.