### PR TITLE
[BUGFIX] Solved invalid issue when using www in domain

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -97,7 +97,7 @@ class Data extends AbstractHelper
      */
     public function getRequestToWebsiteId($request)
     {
-        $baseUrl = str_replace('www.', '%', $request->getDistroBaseUrl());
+        $baseUrl = str_replace('www.', '', $request->getDistroBaseUrl());
         // Strip schemas
         $baseUrl = str_replace(['https://', 'http://'], '', $baseUrl);
 


### PR DESCRIPTION
When the domain in the config contains www the query which is used has a like query with %%example.com which is an invalid query.